### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-output/* linguist-vendored


### PR DESCRIPTION
This will help show the correct language used for the Solution. Adding the .gitattributes will show the language of repo as Java instead of HTML